### PR TITLE
Prevent duplicate hook execution

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -6,8 +6,6 @@
 set -e
 
 source ${OPENSHIFT_REPO_DIR}/.openshift/action_hooks/common
-source ${OPENSHIFT_REPO_DIR}/.openshift/action_hooks/build
-source ${OPENSHIFT_REPO_DIR}/.openshift/action_hooks/deploy
 
 echo "Starting nginx."
 ${OPENSHIFT_RUNTIME_DIR}/nginx/sbin/nginx


### PR DESCRIPTION
If i understand correctly, OpenShift already executes hooks named "build" and "deploy" by convention, so source-ing these files here makes those hooks execute twice needlessly.
