### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Just do `git update-index --chmod=+x -- $(git ls-files .openshift/action_hooks/*
 #### Openshift disconnects on build
 This seems to be a problem within openshift (see https://www.openshift.com/forums/openshift/openshift-build-timeout).
 
-To resume the build, first make an arbitary change to your local repo (e.g. add some text to README.md), commit that change and then do another `git push --force "openshift" master:master`.
+To resume the build, first make an arbitrary change to your local repo (e.g. add some text to README.md), commit that change and then do another `git push --force "openshift" master:master`.
 
 #### Other
 Maybe have a look at [stackoverflow](http://stackoverflow.com/questions/tagged/openshift) and if you end up empty-handed just [create a issue](https://github.com/boekkooi/openshift-diy-nginx-php/issues).


### PR DESCRIPTION
@boekkooi, I've corrected a typographical error in the documentation of the [openshift-diy-nginx-php](https://github.com/boekkooi/openshift-diy-nginx-php) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.